### PR TITLE
CSSの追加の仕方を変更

### DIFF
--- a/cs-shop.php
+++ b/cs-shop.php
@@ -252,5 +252,9 @@ if (is_admin()) {
     add_shortcode("csshop", "csshop_view");
 
     // CSSをヘッダに追加
-    add_action('wp_head', 'csshop_css');
+    function cs_shop_enqueue_scripts() {
+      wp_enqueue_style( 'cs-shop', CS_SHOP_URL . "/cs-shop.css" );
+    }
+
+    add_action( 'wp_enqueue_scripts', 'cs_shop_enqueue_scripts' );
 }


### PR DESCRIPTION
### 修正したい点
- CSSの読み込みがhead内の下の方に入ってしまい、cssのカスタマイズがしにくかった
### 対応

wordpressの持つwp_enqueue_styleを使うことで
css間の依存関係がある程度制御でき、カスタマイズしやすくなる。
https://wpdocs.osdn.jp/%E9%96%A2%E6%95%B0%E3%83%AA%E3%83%95%E3%82%A1%E3%83%AC%E3%83%B3%E3%82%B9/wp_enqueue_style
